### PR TITLE
Few issues with images and links

### DIFF
--- a/docs/getting-started/connecting-to-rc.md
+++ b/docs/getting-started/connecting-to-rc.md
@@ -34,7 +34,7 @@ Connect to the portal using your web browser at [https://portal.hpc.psu.edu]
 
 For more advanced tasks, users can access the command line interface through the portal under the "Clusters" menu:
 
-![Cluster menu Portal Image][..img/RCPortalShell.png]
+![Cluster menu Portal Image](..img/RCPortalShell.png)
 
 ## Connecting via SSH
 

--- a/docs/getting-started/connecting-to-rc.md
+++ b/docs/getting-started/connecting-to-rc.md
@@ -34,7 +34,7 @@ Connect to the portal using your web browser at [https://portal.hpc.psu.edu]
 
 For more advanced tasks, users can access the command line interface through the portal under the "Clusters" menu:
 
-![..img/RCPortalShell.png]
+![Cluster menu Portal Image][..img/RCPortalShell.png]
 
 ## Connecting via SSH
 

--- a/docs/running-jobs/submitting-jobs.md
+++ b/docs/running-jobs/submitting-jobs.md
@@ -122,7 +122,7 @@ The Roar Portals are simple graphical web interfaces that provide users with acc
 Users can submit and monitor jobs, manage files, and run applications using just a web browser. 
 To access the Roar Portals, users must log in using valid Penn State access account credentials and must also have an account on Roar. 
 
-The [RC Portal](https://rcportal.hpc.psu.edu) is available at the following webpage: [https://rcportal.hpc.psu.edu](https://rcportal.hpc.psu.edu)
+The [RC Portal](https://portal.hpc.psu.edu) is available at the following webpage: [https://portal.hpc.psu.edu](https://portal.hpc.psu.edu)
 
 The [RR Portal](https://rrportal.hpc.psu.edu) is available at the following webpage: [https://rrportal.hpc.psu.edu](https://rrportal.hpc.psu.edu)
 

--- a/docs/running-jobs/submitting-jobs.md
+++ b/docs/running-jobs/submitting-jobs.md
@@ -344,6 +344,11 @@ Specifically, the following command displays all running and queued jobs for a s
 $ squeue -u <user>
 ```
 
+To obtain the expected start time (worst case scenario) of the jobs scheduled for a specific user, we can use the command: 
+```
+$ squeue -u <user> --start
+```
+
 A useful environment variable is the `SQUEUE_FORMAT` variable which enables customization of the details shown by the `squeue` command. 
 This variable can be set, for example, with the following command to provide a highly descriptive `squeue` output:
 


### PR DESCRIPTION
1. This is the old picture with the previous https://rcportal.hpc.psu.edu mentioned instead of the latest https://portal.hpc.psu.edu  inside the image
(Location of image : img/RCPortalShell.png)
https://docs.icds.psu.edu/getting-started/connecting-to-rc/#connecting-via-the-web-portal
Corrected the code but not replaced the older image yet.

2. Changing the old portal link rcportal.hpc.psu.edu to portal.hpc.psu.edu
3. added squeue -u user --start to the documentation
