### PR TITLE
hardware table correction, GPU resource request, sbatch arguments

### DIFF
--- a/docs/getting-started/compute-hardware.md
+++ b/docs/getting-started/compute-hardware.md
@@ -13,7 +13,7 @@ The different types of nodes available on Roar are:
 | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
 | Basic | 120 <br> 240 | 64 <br> 24 | 256 <br> 128 | Gold 6430 <br> E5-2650v4 | sapphirerapids <br> broadwell | Ethernet|
 | Standard | 140 <br> 156 <br> 233 <br> 36 | 48 <br> 48 <br> 24 <br> 64 | 512 <br> 384 <br> 256 <br> 384 | Gold 6342 <br> Gold 6248R <br> E5-2680v3 <br> EPYC 9354 | icelake <br> cascadelake <br> haswell <br> AMD Genoa | Infiniband |
-| GPU A100 <br> (40GB) | 38 | 48 | 384 | Gold 6248R | cascadelake | Infiniband |
+| 2xGPU A100 <br> (40GB) | 38 | 48 | 384 | Gold 6248R | cascadelake | Infiniband |
 | GPU V100 <br> (32GB)| 2 | 24 | 512 | E5-2680v3 | haswell | Ethernet |
 | 4xGPU V100 <br> (32GB) | 2|  24 | 512 | Gold 6132 | skylake | Ethernet |
 | GPU A40 <br> (48GB) | 12 | 36 | 1024 | Gold 6354 | icelake | Ethernet |

--- a/docs/running-jobs/batch-jobs.md
+++ b/docs/running-jobs/batch-jobs.md
@@ -78,13 +78,12 @@ which is the directory from which the job was submitted.
 ```
 sbatch myScript.sh arg1 arg2
 ```
-In the script, arguments `arg1` and `arg2` can be accessed with `$1` and `$2` as usual.
+In the script, arguments `arg1` and `arg2` can be accessed with `$1` and `$2` as usual.  
 `sbatch` can also pass values by assigning variables like this:
 ```
 sbatch --export=VAR1=arg1, VAR2=arg2 myScript.sh
 ```
 In the script, `$VAR1` and `$VAR2` are set to `arg1` and `arg2`.
-
 
 For more information on partitions, see [Partitions][partitions].  
 For more information on hardware requests, see [Hardware requests][hardware].

--- a/docs/running-jobs/batch-jobs.md
+++ b/docs/running-jobs/batch-jobs.md
@@ -74,6 +74,18 @@ lines with `#` other than `#SBATCH` are ordinary bash script comments.
 Most scripts start with `cd $SLURM_SUBMIT_DIR`,
 which is the directory from which the job was submitted.
 
+`sbatch` can pass arguments to batch scripts like this:
+```
+sbatch myScript.sh arg1 arg2
+```
+In the script, arguments `arg1` and `arg2` can be accessed with `$1` and `$2` as usual.
+`sbatch` can also pass values by assigning variables like this:
+```
+sbatch --export=VAR1=arg1, VAR2=arg2 myScript.sh
+```
+In the script, `$VAR1` and `$VAR2` are set to `arg1` and `arg2`.
+
+
 For more information on partitions, see [Partitions][partitions].  
 For more information on hardware requests, see [Hardware requests][hardware].
 [partitions]: ../getting-started/compute-hardware.md#partitions

--- a/docs/running-jobs/hardware-requests.md
+++ b/docs/running-jobs/hardware-requests.md
@@ -17,7 +17,6 @@ For a batch job paid by a credit account, to request a single GPU:
 
 To request n GPUs, replace 1 above by n.  
 To request a specific model of GPU, use `--gres=gpu:a100:1`.
-(Alternative syntax: `--gpus=1` and `--gpus=a100:1`.)
 
 For an interactive job paid by a credit account, use `salloc`:
 ```

--- a/docs/running-jobs/hardware-requests.md
+++ b/docs/running-jobs/hardware-requests.md
@@ -17,6 +17,7 @@ For a batch job paid by a credit account, to request a single GPU:
 
 To request n GPUs, replace 1 above by n.  
 To request a specific model of GPU, use `--gres=gpu:a100:1`.
+(Alternative syntax: `--gpus=1` and `--gpus=a100:1`.)
 
 For an interactive job paid by a credit account, use `salloc`:
 ```


### PR DESCRIPTION
-- small fix to hardware table (2xA100, not A100)
-- alternative syntax to GPU resource request
-- description of how sbatch handles arguments to scripts