### PR TITLE
Fix links for running-jobs and file-system

### DIFF
--- a/docs/file-system/finding-files.md
+++ b/docs/file-system/finding-files.md
@@ -26,7 +26,7 @@ Google searches on these commands are often helpful
 (e.g., "Unix how to find and delete large files").
 Here are a few examples of each.
 [unix_tutorial2]: https://www.tutorialspoint.com/unix/unix_tutorial.pdf
-[grep_tutorial]: https://danielmiessler.com/p/grep/
+[grep_tutorial]: https://danielmiessler.com/blog/grep
 [find_tutorial]: https://snapshooter.com/learn/linux/find
 
 ## Searching for files (find)

--- a/docs/file-system/transferring-files.md
+++ b/docs/file-system/transferring-files.md
@@ -86,7 +86,7 @@ available for [Linux](https://docs.globus.org/globus-connect-personal/install/li
 
 In addition to providing a robust data transfer option, Globus can also be used to share 
 data with collaborators by creating 
-[Guest Collections](https://docs.globus.org/how-to/guest-collection-share-and-access/). 
+[Guest Collections](https://docs.globus.org/guides/tutorials/manage-files/share-files/). 
 Collections can be set up with a variety of sharing options from complete public access 
 to individual user-level permission levels.
 

--- a/docs/running-jobs/interactive-jobs.md
+++ b/docs/running-jobs/interactive-jobs.md
@@ -40,7 +40,7 @@ Under a paid allocation (that includes GPU nodes), use
 salloc --account=<your_allocation> --partition=sla-prio --ntasks=4 --mem=32G --time=01:00:00 --gres=gpu:a100:1
 ```
 
-For more details, see [Hardware requests](resource-requests.md).
+For more details, see [Resource requests](resource-requests.md).
 
 ## Firefox
 

--- a/docs/running-jobs/portal.md
+++ b/docs/running-jobs/portal.md
@@ -43,12 +43,12 @@ specific type required (e.g., standard CPU or GPU-enabled node).
 ### Advanced Slurm Options
 
 Using Advanced Slurm options allows you to enter custom 
-[Resource directives](./slurm.md#resource-directives). These options allow you to fully 
+[Resource directives](./slurm-scheduler.md#resource-directives). These options allow you to fully 
 customize your hardware allocation even allowing you to override the form restrictions 
 for node and core count, memory, and runtime.
 
 To do this, on a job submit form, ensure the "Enable advanced Slurm options" box is checked. 
-This will cause the "Sbatch options" box to appear. Enter the desired [Resource directives](slurm.md#resource-directives) here.
+This will cause the "Sbatch options" box to appear. Enter the desired [Resource directives](./slurm-scheduler.md#resource-directives) here.
 
 For example, to request 8 cores (tasks), 128GB memory, and 8 hour run time - the Sbatch options box 
 should contain:
@@ -86,7 +86,7 @@ For more information, please see the
 
 To run your job using a [credit account or allocation](../accounts/paid-resources.md),
 select the relevant account ID from the Account drop-down menu. Then select a corresponding 
-[partition](../system/system-overview.md$#partitions).
+[partition](../system/system-overview.md#partitions).
 
  - Credit accounts need to use one of the hardware partitions: `basic`, `standard`, `himem`, or `interactive`
  - Allocations need to use the `sla-prio` partition 


### PR DESCRIPTION
Changes - 

1 ./running-jobs/portal/ 
Links - 
Advanced slurm options - "Resource directives" link fixed
Using paid accounts- "partition" link fixed


2 ./interactive-jobs/
Links - 
Command line interactive sessions - "Hardware requests" link, changed text to "resource requests"


3 ./file-system/finding-files/
Finding files -> grep guide link fixed.


4 ./file-system/transferring-files/
Globus Guest Collections -> "Guest Collections" link fixed with official globus guide on how to share globus files using guest collections


